### PR TITLE
Fitting polarization measurements (positive OR negative jumps)

### DIFF
--- a/brutus/los.py
+++ b/brutus/los.py
@@ -117,6 +117,10 @@ def LOS_clouds_priortransform(u, rlims=(0., 6.), dlims=(4., 19.),
     if dust_template:
         # replace with rescalings for the template
         x[s+3::2] = u[s+3::2][np.argsort(u[s+2::2])] * (nlims[1] - nlims[0]) + nlims[0]
+        
+
+    return x
+
 
 
 def LOS_clouds_loglike_samples(theta, dsamps, rsamps, kernel='gauss',

--- a/brutus/los.py
+++ b/brutus/los.py
@@ -105,17 +105,18 @@ def LOS_clouds_priortransform(u, rlims=(0., 6.), dlims=(4., 19.),
     else:
         s = 0
 
-    # reddening
-    x[s+1::2] = np.sort(u[s+1::2]) * (rlims[1] - rlims[0]) + rlims[0]
+    # distances
+    x[s+2::2] = np.sort(u[s+2::2]) * (dlims[1] - dlims[0]) + dlims[0]
+        
+    # foreground reddening    
+    x[s+1] = u[s+1] * (rlims[1] - rlims[0]) + rlims[0]
+
+    # cloud reddenings
+    x[s+3::2] = (u[s+3::2][np.argsort(u[s+2::2])]) * (rlims[1] - rlims[0]) + rlims[0]
 
     if dust_template:
         # replace with rescalings for the template
-        x[s+3::2] = np.sort(u[s+3::2]) * (nlims[1] - nlims[0]) + nlims[0]
-
-    # distances
-    x[s+2::2] = np.sort(u[s+2::2]) * (dlims[1] - dlims[0]) + dlims[0]
-
-    return x
+        x[s+3::2] = u[s+3::2][np.argsort(u[s+2::2])] * (nlims[1] - nlims[0]) + nlims[0]
 
 
 def LOS_clouds_loglike_samples(theta, dsamps, rsamps, kernel='gauss',


### PR DESCRIPTION
This required a slight modification to how sorting is done in the prior transform function in los.py. I first sort the distances and then sort the reddenings based on their corresponding distances. Previously we sort the distances and then sort the reddenings independently from the distances. In the new way, the foreground reddening is treated independently and I'm only sorting the cloud reddenings. 