### PR TITLE
Fix test failure: replace removed np.trapz with scipy.integrate.trapezoid

### DIFF
--- a/tests/test_utils/test_math_comprehensive.py
+++ b/tests/test_utils/test_math_comprehensive.py
@@ -384,8 +384,12 @@ class TestMathIntegration:
         x = np.linspace(a, b, 1000)  # Integration range should match truncation bounds
         pdf_vals = truncnorm_pdf(x, a, b)
 
-        # Numerical integration (trapezoidal rule)
-        integral = np.trapz(pdf_vals, x)
+        # Numerical integration (trapezoidal rule). Use scipy's trapezoid,
+        # which is stable across NumPy versions (np.trapz was removed in
+        # NumPy 2.0 in favor of np.trapezoid).
+        from scipy.integrate import trapezoid
+
+        integral = trapezoid(pdf_vals, x)
         np.testing.assert_almost_equal(integral, 1.0, decimal=2)
 
         # Test that chi-square probabilities are reasonable


### PR DESCRIPTION
np.trapz was removed in NumPy 2.0 in favor of np.trapezoid. Using
scipy.integrate.trapezoid keeps the test compatible across the full
supported NumPy range (>=1.19), since np.trapezoid is unavailable on
older NumPy and np.trapz is unavailable on NumPy 2.0+.

https://claude.ai/code/session_017NJQBdwLRkDy3KiErhHAb1